### PR TITLE
Ignore component subject ids on kana vocab

### DIFF
--- a/projections.user.js
+++ b/projections.user.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name         WKStats Projections Page
-// @version      1.4.0
+// @version      1.4.1
 // @description  Make a temporary projections page for WKStats
 // @author       UInt2048
 // @match        https://www.wkstats.com/*

--- a/projections.user.js
+++ b/projections.user.js
@@ -227,7 +227,7 @@
 
             const unlock = function(item, itemLevel, burn) {
                 return P.countComponent(item.data.level, itemLevel) ?
-                    (item.object === "radical" ? 0 : item.data.component_subject_ids.
+                    (item.object === "radical" || item.object === "kana_vocabulary" ? 0 : item.data.component_subject_ids.
                      map(id => Math.max(0, unlock(items.find(o => o.id === id), item.data.level))).
                      reduce((a, b) => Math.max(a, b))) + time(item, burn) : 0;
             };


### PR DESCRIPTION
WaniKani recently released an update with [kana only vocab](https://tofugu.notion.site/WaniKani-Updates-cef4c0d53cda41518eb2fbf02a9294fb?p=87724206f9e6480aa39d8f2962b35d43&pm=s). This broke the `unlock` function because for items marked as `"kana_vocabulary"` the property `component_subject_ids` does not exist.